### PR TITLE
added logging in parent thread

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,10 +37,7 @@ var Utils = module.exports = {
         if( SPAWN_COUNT < SPAWN_MAX_LIVE || cfg.force ){
             SPAWN_COUNT++;
 
-            var beginLog = JSON.parse(cfg.opts.env._grunt_multi_info).beginLog;
-            if (beginLog) {
-                grunt.log.ok('Spawning in new thread: ' + beginLog );
-            }
+            grunt.log.ok('Spawning new grunt-multi process');
 
             var child = grunt.util.spawn( cfg, function(){
                 process.nextTick(function(){


### PR DESCRIPTION
Hi @neekey

Thank you for the very useful tool. I am building a complex integration and build tool, and grunt-multi is a key component! I noticed one strange behavior: The `logBegin` message does not appear in the output until each child process finishes. I think that this is because the output from the child processes is not being written to the stdout of the parent process until the child exits. 

I am providing a simple fix here that prints the `logBegin` message from lib.utils.js before spawning the child process. 

This probably adds functionality that is too specific into utils.js, but I don't see any other way. I did already try adding the stdio: 'inherit' property to the spawn process with no success, but am open to suggestions.
