### PR TITLE
add preservation of --no-write arg

### DIFF
--- a/tasks/multi.js
+++ b/tasks/multi.js
@@ -210,6 +210,10 @@ module.exports = function (grunt) {
                 if( grunt.util._.indexOf( process.argv, '--debug' ) >= 0 ){
                     args.push( '--debug' );
                 }
+                // preserve --no-write as well
+                if( grunt.util._.indexOf( process.argv, '--no-write' ) >= 0 ){
+                    args.push( '--no-write' );
+                }
 
                 var beginLogString = '';
 


### PR DESCRIPTION
The --no-write argument can be specified when calling grunt. If it is, then files should not be written: this is a good way of testing before running the task. I think that if the user specifies --no-write, then all child processes spawned by multi should be given the --no-write arg as well. 

Note: From your comment (pasted below), it seems that you originally passed all args from the parent to the child process. Why did you remove this? Would you be willing to put it back in? If not, I suggest that you update the comment.

``` js
 /**
                   * Remove the `node` and `grunt` from argv，and keep the rest as it is.
                   * use `--multi-single` to indicate the thread is a single task generated my Multi.
                   * use `--multi-cfg` to pass the single configuration to child process
                   * note the configuration is stringify and encoded.
                   */
```

Thanks.
