### PR TITLE
Fixed options typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Available options:
 - `vars`: variables can be used within the next option `config`, in fact `var` is a list, you can get the list by `file pattern`, `array`, `function`(return a list).
 - `config`: the config item you want to change, you can use `vars` as template variables.
 - `tasks`: the tasks you want to run.
-- `continue`: if set to `true`, you indicate that the task will not stop. ( example: watch ).
+- `continued`: if set to `true`, you indicate that the task will not stop. ( example: watch ).
 - `logBegin`: Function, return log content you want to put in front of a thread.
 - `logEnd`: Function, return log content you want to put after a thread finish.
 - `maxSpawn`: The max number of spawns that can run at the same time.
@@ -171,7 +171,7 @@ Available options:
 ### Specify `vars` with command
 
 ```bash
-$ grunt multi:func --page_list a,b,c --outTarget mod2.js
+$ grunt multi:func --page_list=a,b,c --outTarget=mod2.js
 ```
 Note that this will override the configuration in `gruntfile.js`.
 


### PR DESCRIPTION
Just fixing a typo where README states that the option for tasks like watch is `continue`, but the code actually looks for `continued`.

I chose to change the README not the code to maintain backward compatibility for people who is already using `continued : true` (like me).

An off-topic question. There is some reason why 0.0.6 is not merged in master?

Thanks for this excellent tool!
