### PR TITLE
Added option to specify tasks in the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,9 @@ $ grunt multi:func --page_list=a,b,c --outTarget=mod2.js
 
 ### Specify `tasks` with command (comma separated)
 ```bash
-$ grunt multi:func --multi-tasks=compile
+$ grunt multi:func --option-tasks=compile
 
-$ grunt multi:func --multi-tasks=jshint,build
+$ grunt multi:func --option-tasks=jshint,build
 ```
 
 Note these options will override the configuration in `Gruntfile.js`.

--- a/README.md
+++ b/README.md
@@ -181,6 +181,11 @@ $ grunt multi:func --option-tasks=compile
 $ grunt multi:func --option-tasks=jshint,build
 ```
 
+### Specify `maxSpawn` with command
+```bash
+$ grunt multi:func --option-max-spawn=10
+```
+
 Note these options will override the configuration in `Gruntfile.js`.
 
 ### How to decide if its a multi-single thread.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Available options:
 - `vars`: variables can be used within the next option `config`, in fact `var` is a list, you can get the list by `file pattern`, `array`, `function`(return a list).
 - `config`: the config item you want to change, you can use `vars` as template variables.
 - `tasks`: the tasks you want to run.
-- `continue`: if set to `true`, you indicate that the task will not stop. ( example: watch ).
+- `continued`: if set to `true`, you indicate that the task will not stop. ( example: watch ).
 - `logBegin`: Function, return log content you want to put in front of a thread.
 - `logEnd`: Function, return log content you want to put after a thread finish.
 - `maxSpawn`: The max number of spawns that can run at the same time.
@@ -171,9 +171,17 @@ Available options:
 ### Specify `vars` with command
 
 ```bash
-$ grunt multi:func --page_list a,b,c --outTarget mod2.js
+$ grunt multi:func --page_list=a,b,c --outTarget=mod2.js
 ```
-Note that this will override the configuration in `gruntfile.js`.
+
+### Specify `tasks` with command (comma separated)
+```bash
+$ grunt multi:func --multi-tasks=compile
+
+$ grunt multi:func --multi-tasks=jshint,build
+```
+
+Note these options will override the configuration in `Gruntfile.js`.
 
 ### How to decide if its a multi-single thread.
 

--- a/tasks/multi.js
+++ b/tasks/multi.js
@@ -116,6 +116,20 @@ module.exports = function (grunt) {
                     return;
                 }
 
+                if( name == 'multi-tasks' && values ){
+
+                    values = values.split( ',' );
+
+                    if( values.length == 1 ){
+                        tasks = values[ 0 ];
+                    }
+                    else {
+                        tasks = values;
+                    }
+
+                    return;
+                }
+
                 if( name && values ){
 
                     if( !vars ){

--- a/tasks/multi.js
+++ b/tasks/multi.js
@@ -79,11 +79,6 @@ module.exports = function (grunt) {
         var configs = [];
 
         /**
-         * Set max spawn
-         */
-        Util.spawn.setMax( maxSpawn );
-
-        /**
          * Separate the option.config
          */
         grunt.util._.each( options.config, function( cfg, key ){
@@ -129,6 +124,9 @@ module.exports = function (grunt) {
                         else {
                             tasks = values;
                         }
+                    }
+                    else if( name == 'max-spawn' && !isNaN(values) && values > 0 ){
+                        maxSpawn = parseInt(values, 10);
                     }
 
                     return;
@@ -238,6 +236,11 @@ module.exports = function (grunt) {
                 if( grunt.util._.isFunction( logBegin ) ){
                     beginLogString = logBegin( configDatas[ index ] );
                 }
+
+                /**
+                 * Set max spawn
+                 */
+                Util.spawn.setMax( maxSpawn );
 
                 Util.spawn( grunt, {
                     grunt: true,

--- a/tasks/multi.js
+++ b/tasks/multi.js
@@ -105,26 +105,30 @@ module.exports = function (grunt) {
 
         grunt.option.flags().forEach(function( flag ){
 
-            var EX = /--([^=]+)=(.*)/;
+            var EX = /--(option-)?([^=]+)=(.*)/;
             var ret = EX.exec( flag );
 
             if( ret ){
-                var name = ret[ 1 ];
-                var values = ret[ 2 ];
+                var name = ret[ 2 ];
+                var values = ret[ 3 ];
+                var isOption = !grunt.util._.isUndefined( ret[ 1 ] );
 
                 if( name == 'debug' ){
                     return;
                 }
 
-                if( name == 'multi-tasks' && values ){
+                if( isOption && values ){
 
-                    values = values.split( ',' );
+                    if( name == 'tasks' ){
 
-                    if( values.length == 1 ){
-                        tasks = values[ 0 ];
-                    }
-                    else {
-                        tasks = values;
+                        values = values.split( ',' );
+
+                        if( values.length == 1 ){
+                            tasks = values[ 0 ];
+                        }
+                        else {
+                            tasks = values;
+                        }
                     }
 
                     return;


### PR DESCRIPTION
I've added an option to specify the tasks to run in a grunt-multi task directly from command line

#### Usage

```bash
#single task
grunt multi:any_task --multi-tasks=compile

#multiple comma separated tasks
grunt multi:any_task --multi-tasks=jshint,build
```

This is especially useful when you want to use a existing vars/config blocks of a grunt-multi task but running different tasks than the ones specified in the task.

obs.: This PR also includes the typo fixes from PR #4 