### PR TITLE
Added option to specify the continued flag in the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Available options:
 - `vars`: variables can be used within the next option `config`, in fact `var` is a list, you can get the list by `file pattern`, `array`, `function`(return a list).
 - `config`: the config item you want to change, you can use `vars` as template variables.
 - `tasks`: the tasks you want to run.
-- `continue`: if set to `true`, you indicate that the task will not stop. ( example: watch ).
+- `continued`: if set to `true`, you indicate that the task will not stop. ( example: watch ).
 - `logBegin`: Function, return log content you want to put in front of a thread.
 - `logEnd`: Function, return log content you want to put after a thread finish.
 - `maxSpawn`: The max number of spawns that can run at the same time.
@@ -171,9 +171,17 @@ Available options:
 ### Specify `vars` with command
 
 ```bash
-$ grunt multi:func --page_list a,b,c --outTarget mod2.js
+$ grunt multi:func --page_list=a,b,c --outTarget=mod2.js
 ```
-Note that this will override the configuration in `gruntfile.js`.
+
+### Specify `continued` with command (defaults to `true`)
+```bash
+$ grunt multi:func --continued
+
+$ grunt multi:func --continued=true|false
+```
+
+Note these options will override the configuration in `Gruntfile.js`.
 
 ### How to decide if its a multi-single thread.
 

--- a/README.md
+++ b/README.md
@@ -176,9 +176,9 @@ $ grunt multi:func --page_list=a,b,c --outTarget=mod2.js
 
 ### Specify `continued` with command (defaults to `true`)
 ```bash
-$ grunt multi:func --continued
+$ grunt multi:func --option-continued
 
-$ grunt multi:func --continued=true|false
+$ grunt multi:func --option-continued=true|false
 ```
 
 Note these options will override the configuration in `Gruntfile.js`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "grunt-multi",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "Run Grunt task with multi-configuration.",
     "scripts": {
         "test": "mocha -t 0 -R spec"

--- a/tasks/multi.js
+++ b/tasks/multi.js
@@ -100,10 +100,10 @@ module.exports = function (grunt) {
 
         /**
          * Accepts continued as a parameter
-         * --continued=true|false
+         * --option-continued=true|false
         */
-        if( !grunt.util._.isUndefined( grunt.option('continued') ) ){
-            ifContinued = String(grunt.option('continued')).toLowerCase() == "true";
+        if( !grunt.util._.isUndefined( grunt.option('option-continued') ) ){
+            ifContinued = String( grunt.option('option-continued') ).toLowerCase() == "true";
         }
 
         /**
@@ -120,7 +120,7 @@ module.exports = function (grunt) {
                 var name = ret[ 1 ];
                 var values = ret[ 2 ];
 
-                if( name == 'debug' || name == 'continued' ){
+                if( name == 'debug' ){
                     return;
                 }
 

--- a/tasks/multi.js
+++ b/tasks/multi.js
@@ -99,6 +99,14 @@ module.exports = function (grunt) {
         configStr = JSON.stringify( configNotFunc );
 
         /**
+         * Accepts continued as a parameter
+         * --continued=true|false
+        */
+        if( !grunt.util._.isUndefined( grunt.option('continued') ) ){
+            ifContinued = String(grunt.option('continued')).toLowerCase() == "true";
+        }
+
+        /**
          * Check if there is any flags specified
          * --deb=a.b,hello,hhaah
          */
@@ -112,7 +120,7 @@ module.exports = function (grunt) {
                 var name = ret[ 1 ];
                 var values = ret[ 2 ];
 
-                if( name == 'debug' ){
+                if( name == 'debug' || name == 'continued' ){
                     return;
                 }
 


### PR DESCRIPTION
I've added an option to set the `continued` flag of a grunt-multi task directly from command line

#### Usage

```bash
#defaults to true
grunt multi:any_task --continued

#switches to true or false
grunt multi:any_task --continued=true|false
```

This was created with the changes of the PR #5 in mind, but can also be used independently to turn on/off the `continued` flag in any grunt-multi task.

obs.: This PR also includes the typo fixes from PR #4, but NOT the changes from PR #5!