### PR TITLE
Allow definition of global (task) options or target specifc options

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,15 +163,82 @@ Available options:
 - `vars`: variables can be used within the next option `config`, in fact `var` is a list, you can get the list by `file pattern`, `array`, `function`(return a list).
 - `config`: the config item you want to change, you can use `vars` as template variables.
 - `tasks`: the tasks you want to run.
-- `continue`: if set to `true`, you indicate that the task will not stop. ( example: watch ).
+- `continued`: if set to `true`, you indicate that the task will not stop. ( example: watch ).
 - `logBegin`: Function, return log content you want to put in front of a thread.
 - `logEnd`: Function, return log content you want to put after a thread finish.
 - `maxSpawn`: The max number of spawns that can run at the same time.
 
+Options can be specified globally for all `multi` targets and individually within each `multi:target`.
+
+##### Task options (all targets)
+
+```js
+//Both targets (list and constant_func) will inherit task options
+//and wiil have the vars.page_list = [ 'a', 'b', 'c' ]
+multi: {
+    options : {
+        vars: {
+            page_list: [ 'a', 'b', 'c' ]
+        }
+    },
+    list: {
+        options: {
+            config: {
+                targetPage: '<%= page_list %>'
+            },
+            tasks: [ 'copy' ]
+        }
+    },
+    constant_func: {
+        options: {
+            config: {
+                targetPage: function( vars, rawConfig ){ return vars.page_list; },
+            },
+            tasks: [ 'copy' ]
+        }
+    }
+}
+```
+
+##### Target specific options
+
+```js
+//Both targets (list and constant_func) will inherit task options
+//but only list target will have vars.page_list = [ 'a', 'b', 'c' ]
+//In the constant_func target the global vars.page_list will be
+//overwritten by the target specific option vars.page_list = [ 'x', 'y', 'z' ]
+multi: {
+    options : {
+        vars: {
+            page_list: [ 'a', 'b', 'c' ]
+        }
+    },
+    list: {
+        options: {
+            config: {
+                targetPage: '<%= page_list %>'
+            },
+            tasks: [ 'copy' ]
+        }
+    },
+    constant_func: {
+        options: {
+            vars: {
+                page_list: [ 'x', 'y', 'z' ]
+            },
+            config: {
+                targetPage: function( vars, rawConfig ){ return vars.page_list; },
+            },
+            tasks: [ 'copy' ]
+        }
+    }
+}
+```
+
 ### Specify `vars` with command
 
 ```bash
-$ grunt multi:func --page_list a,b,c --outTarget mod2.js
+$ grunt multi:func --page_list=a,b,c --outTarget=mod2.js
 ```
 Note that this will override the configuration in `gruntfile.js`.
 

--- a/tasks/multi.js
+++ b/tasks/multi.js
@@ -51,7 +51,14 @@ module.exports = function (grunt) {
         grunt.log.debug( 'Begin Multi tasks.' );
 
         // Get the raw `multi` config, in case the glob-patterns have been replaced by grunt automatically.
-        var options = grunt.config.getRaw( this.name )[ this.target ].options;
+        var taskOptions = grunt.config.getRaw( this.name ).options;
+        var targetOptions = grunt.config.getRaw( this.name )[ this.target ].options;
+        // Merges global task options with target specific options
+        var allOptions = [{}].concat([
+            grunt.util.kindOf(taskOptions) === 'object' ? taskOptions : {},
+            grunt.util.kindOf(targetOptions) === 'object' ? targetOptions : {}
+        ]);
+        var options = grunt.util._.extend.apply(null, allOptions);
         var maxSpawn = options.maxSpawn;
         var vars = options.vars;
         var logBegin = options.logBegin;


### PR DESCRIPTION
In this PR I've added the ability to set global (task) options in addition to the, already there, target specific options.

This is a real-world need for the project I'm working on, where we have some targets with different configs/tasks blocks but with the same vars, so I decided to add it back to the official repo.

Following your comment about Grunt replacing blob patterns automatically in config, I decided to not use Grunt's built-in functions for the merge, instead I dug down to the `task.options()` function in `grunt/task.js` and tried to mimic the internal functionality without loosing (or converting) any data.

I could have simply used _.extend, but I chose to stick with the Grunt's internal implementation to maintain the code consistency and avoid any problems that they probably already got rid of (like objects passed as reference getting modified during merge).

_Important note_: Keys with the same name in the global and target specific options WILL be overwritten! I'm NOT merging them, since this is the default behavior I'm mimicking.

I don't know if this PR will be merged, but I honestly think it is a great addition. At least for my team needs.

obs.: This PR also includes the typo fixes from PR #4.
